### PR TITLE
Update anx-reader to version 1.6.1

### DIFF
--- a/bucket/anx-reader.json
+++ b/bucket/anx-reader.json
@@ -1,13 +1,13 @@
 {
-  "version": "1.6.0",
+  "version": "1.6.1",
   "homepage": "https://github.com/Anxcye/anx-reader",
   "description": "跨平台电子书阅读器",
   "license": {
     "identifier": "AGPL-3.0",
     "url": "https://github.com/Anxcye/anx-reader/blob/main/LICENSE"
   },
-  "url": "https://github.com/Anxcye/anx-reader/releases/download/v1.6.0/Anx-Reader-windows-1.6.0.zip",
-  "hash": "4e594130e51f989608071f0a76d29f460961c32940413cb0a33f0b2d549552cc",
+  "url": "https://github.com/Anxcye/anx-reader/releases/download/v1.6.1/Anx-Reader-windows-1.6.1.zip",
+  "hash": "5c3b8338e2e162f741ca29bdb7675979b1b36aa276e011dd23ba326b1fecee57",
   "bin": [
     "anx_reader.exe"
   ],


### PR DESCRIPTION
## 📦 Package Update

This PR updates **anx-reader** from version `1.6.0` to `1.6.1`.

### 🔄 Changes Made
- ✅ Updated version from `1.6.0` to `1.6.1`
- ✅ Updated download URL to point to v1.6.1 release
- ✅ Updated file hash to match the new release file

### 📋 Release Information
**anx-reader v1.6.1** includes the following improvements:

#### ✨ New Features
- Support following book indentation
- Support choosing whether to enable auto-sync
- Add a guide page for first-time users
- Show update log after updating
- Support restoring old versions from history after downloading and overwriting the local database from remote (experimental feature)

#### 🐛 Bug Fixes
- Some Android devices cannot select text and pop up context menu
- Compatibility with older WebView versions, now it may run on WebView version 70 and above
- WebDAV configuration changes now take effect immediately after saving
- Improved sync logic to replace the current database only after confirming the integrity of the new database
- Preserve historical versions when replacing the local database
- PDF files could not be read in the previous version
- Covers could not be synced
- Files with uppercase extensions could not be imported
- Books could not be imported on some Windows devices
- Fixed issue where user notes were lost after changing highlight style
- Fixed issue where PDF files could not be imported

#### 🔧 Other Improvements
- Prepare for supporting more sync protocols
- Optimize build number

### ✅ Verification
- [x] Version number updated correctly
- [x] Download URL is valid and accessible
- [x] File hash matches the release asset
- [x] No breaking changes to the manifest structure

### 📊 Status Summary
- **anx-reader**: 1.6.0 → 1.6.1 ✅ **Updated**
- **sakura-editor**: 2.4.2 ✅ **Already latest**

This update brings the latest stable release with important bug fixes and new features for users.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author