### PR TITLE
feat(windowtabs): add WindowTabs Scoop manifest (v2025.06.30)

### DIFF
--- a/bucket/windowtabs.json
+++ b/bucket/windowtabs.json
@@ -1,0 +1,24 @@
+{
+  "version": "2025.06.30",
+  "homepage": "https://github.com/leafOfTree/WindowTabs",
+  "description": "为桌面带来浏览器式标签窗口管理的工具",
+  "license": "MIT",
+  "url": "https://github.com/leafOfTree/WindowTabs/releases/download/v2025.06.30/WindowTabs.exe",
+  "hash": "da014856cef33c806381d03308f1c8f35c69efbc15d2e5a5c9ebba58f8f26fb5",
+  "bin": "WindowTabs.exe",
+  "shortcuts": [
+    [
+      "WindowTabs.exe",
+      "WindowTabs"
+    ]
+  ],
+  "checkver": {
+    "url": "https://api.github.com/repos/leafOfTree/WindowTabs/releases/latest",
+    "jsonpath": "$.tag_name",
+    "regex": "v([\\d.]+)"
+  },
+  "autoupdate": {
+    "url": "https://github.com/leafOfTree/WindowTabs/releases/download/v$version/WindowTabs.exe"
+  }
+}
+


### PR DESCRIPTION
This PR adds a Scoop manifest for WindowTabs.

- App: WindowTabs
- Upstream: https://github.com/leafOfTree/WindowTabs
- Version: 2025.06.30 (tag v2025.06.30)
- Binary: WindowTabs.exe
- Hash: sha256: da014856cef33c806381d03308f1c8f35c69efbc15d2e5a5c9ebba58f8f26fb5 (from GitHub API asset digest)
- Checkver: latest release tag via GitHub API
- Autoupdate: tag-based URL

Notes:
- Single-file portable exe, no installer required.
- Added Start Menu shortcut entry.

Please review. Thanks!

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author