### PR TITLE
chore(anx-reader): update to v1.8.1

### DIFF
--- a/bucket/anx-reader.json
+++ b/bucket/anx-reader.json
@@ -1,13 +1,13 @@
 {
-  "version": "1.6.1",
+  "version": "1.8.1",
   "homepage": "https://github.com/Anxcye/anx-reader",
   "description": "跨平台电子书阅读器",
   "license": {
     "identifier": "AGPL-3.0",
     "url": "https://github.com/Anxcye/anx-reader/blob/main/LICENSE"
   },
-  "url": "https://github.com/Anxcye/anx-reader/releases/download/v1.6.1/Anx-Reader-windows-1.6.1.zip",
-  "hash": "5c3b8338e2e162f741ca29bdb7675979b1b36aa276e011dd23ba326b1fecee57",
+  "url": "https://github.com/Anxcye/anx-reader/releases/download/v1.8.1/Anx-Reader-windows-1.8.1.zip",
+  "hash": "f0ee249b1ae107a6d62ecf3f4da45e215814c45efe9170cd0a9f5577d217ffc9",
   "bin": [
     "anx_reader.exe"
   ],


### PR DESCRIPTION
Update anx-reader from v1.6.1 to v1.8.1

## Changes
- Version: 1.6.1 → 1.8.1
- URL: Updated to v1.8.1 release asset
- Hash: Updated SHA256 checksum

## Release Notes (v1.8.1)
- Fix: 修复部分 AI 服务无法使用的问题
- Fix: 优化全文翻译的效果

## Verification
- ✅ Version updated
- ✅ Download URL updated
- ✅ SHA256 hash verified from GitHub API
- ✅ Release published on 2025-09-30

Upstream release: https://github.com/Anxcye/anx-reader/releases/tag/v1.8.1

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author